### PR TITLE
Enhance README.md and AnnotationParser with Typed Annotation Helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,34 @@ To test the package:
 ```sh
 pnpm test
 ```
+
+## Typed Annotation Helpers
+
+The `src/Extraction/Annotations.ts` module provides typed helpers for attaching
+and retrieving schema annotations. Use helpers such as:
+
+```ts
+import { Annotations } from "effect-nlp/Extraction/Annotations";
+import { Schema, pipe } from "effect";
+
+const ArticleSchema = pipe(
+  Schema.Struct({
+    title: pipe(
+      Schema.String,
+      Annotations.withCore({
+        title: "Title",
+        description: "Headline used when presenting the article",
+      })
+    ),
+  }),
+  Annotations.withMetadata({
+    semantic: { semanticType: "article" },
+    role: { role: "aggregate_root" },
+  })
+);
+
+const metadata = Annotations.getContext(ArticleSchema.ast.annotations);
+```
+
+These helpers guarantee consistent annotation shapes that can be consumed by
+prompt builders and extraction pipelines.

--- a/docs/entity-extraction-mvp-plan.md
+++ b/docs/entity-extraction-mvp-plan.md
@@ -1,0 +1,131 @@
+# Effect-NLP Entity Extraction MVP Plan
+
+## Objectives
+- Deliver a production-ready MVP for entity extraction backed by Effect Schema AST traversal and @effect/ai prompting.
+- Reduce the public API to the minimal surface necessary to support deterministic extraction, provenance, and storage.
+
+## Critical Fixes
+1. Remove all invalid `Function.dual(1, ...)` usages; replace with plain functions or valid dual arities.
+2. Eliminate `as any` casts in core modules (AnnotationParser, PatternBuilders, WinkUtils, etc.).
+3. Make optional utilities (wink-nlp-utils) injectable layers rather than hard requirements.
+4. Ensure tokenizer offsets and branded indices remain correct (already addressed, keep regression tests).
+
+## Annotation Specification
+- Introduce `src/Extraction/Annotations.ts` defining typed schemas for annotations:
+  - `CoreAnnotations`: title?, description?, examples?, constraints?, documentation?, default?
+  - `RoleAnnotation`: role.
+  - `SemanticAnnotation`: semanticType.
+  - `IdentifierAnnotation`: identifier.
+  - Optional `ProvenanceAnnotation`: source?, comment?.
+- Provide helpers: `annotate(schema, annotations)` and typed getters using `SchemaAST.getAnnotation`.
+- Refactor existing annotations to use encoded typed structures.
+
+## Schema AST Transformations
+- Refactor `src/Extraction/ASTTraverse.ts` to produce a pure `SchemaAstTree`:
+  ```ts
+  interface SchemaAstNode {
+    readonly path: ReadonlyArray<string>;
+    readonly ast: SchemaAST.AST;
+    readonly context: Annotations.Context;
+    readonly children: ReadonlyArray<SchemaAstNode>;
+  }
+  ```
+- Implement folds/compilers:
+  - `buildSchemaAstTree(schema): SchemaAstTree`.
+  - `foldSchemaAst(node, algebra)` for recursive transformations.
+  - `extractLeaves(node)` returning typed leaf descriptions.
+- Guarantee immutability (no in-place stamping or mutation).
+
+## Prompt Builder
+- Add `src/Extraction/Prompt.ts` mapping AST tree to prompt structures:
+  - `PromptPart = { label, description, path, examples, constraints, children }`.
+  - `schemaToPromptParts(tree): PromptPart` (functor-like traversal).
+  - `renderPromptText(parts, options): string` producing deterministic prompts with JSON output instructions.
+- Include configuration (verbose vs compact, include constraints/examples flags).
+
+## Extractor Service (@effect/ai)
+- Create `src/Extraction/ExtractorService.ts` composing WinkTokenizer, SchemaPrompt, and AI client layers.
+- Core methods:
+  - `plan(schema, document): ExtractionPlan` (prompt, expected schema, provenance skeleton).
+  - `extract(schema, document): Effect<ExtractedEntity, ExtractionError, R>` performing prompt generation, LLM call, JSON decode, schema validation, and provenance attachment.
+- Define canonical LLM output schema:
+  ```ts
+  interface FieldResult {
+    readonly value?: unknown;
+    readonly span?: { start: number; end: number };
+    readonly confidence?: number;
+  }
+  ```
+  with recursive structures matching the Effect schema.
+
+## Provenance Tracking
+- Add `src/Extraction/Provenance.ts` to encode provenance:
+  - `Provenance = { documentId, spans: Array<{ path, start, end }>, extractedAt, modelInfo }`.
+  - Helpers to map character offsets to token indices and sentences.
+
+## Entity Store Redesign
+- Replace `Schema.Unknown` storage with canonical JSON schema representation:
+  - `StoredSchema = { schemaId, hash, annotations, format, spec }`.
+  - Persist entity values as validated JSON strings with provenance.
+- Round-trip helpers: `encodeEntityValue`, `decodeEntityValue`.
+- Update `EntityStoreEntry` to include provenance, schema metadata, and value snapshot.
+
+## API Surface Reduction
+- Public exports should include only stable components:
+  - Core data types (`Document`, `Sentence`, `Token`) and `WinkTokenizer` service.
+  - Extraction utilities (`Annotations`, `SchemaAst`, `SchemaPrompt`, `ExtractorService`, `EntityStore`).
+- Move experimental APIs under `internal/` namespaces.
+- Update README and documentation to reflect the reduced surface.
+
+## Testing Strategy
+- **Unit Tests**
+  - Annotations encode/decode and getters.
+  - AST traversal immutability and leaf extraction.
+  - Prompt rendering snapshots.
+  - Extractor service with mocked AI returning JSON.
+  - Wink tokenizer offsets and provenance mapping.
+- **Integration Tests**
+  - Full pipeline: schema → prompt → mocked AI JSON → entity validation → storage round-trip.
+  - Optional smoke test against real AI (skipped in CI).
+- **Property/Snapshot Tests**
+  - Prompt rendering idempotence.
+  - Span bounds validation.
+
+## Milestones
+- **M0: Base Hygiene (1–2 days)**
+  - Remove invalid `Function.dual` usage; replace `as any` in core modules.
+  - Optional layer injection for wink utilities.
+  - ✅ Acceptance: `pnpm tsc`, targeted tests, lint (touched files).
+
+- **M1: Annotations & AST (2–3 days)**
+  - Implement typed annotation spec and refactor parser.
+  - Pure AST traversal with typed tree and fold.
+  - ✅ Acceptance: unit tests + snapshots for annotations/AST.
+
+- **M2: Prompt Builder (2 days)**
+  - Implement prompt functor/renderer with deterministic output.
+  - ✅ Acceptance: snapshot prompts for example schemas.
+
+- **M3: Extractor Service (3–4 days)**
+  - Integrate @effect/ai, plan/extract pipeline, JSON decoding.
+  - ✅ Acceptance: integration test with mocked AI.
+
+- **M4: Storage & Provenance (2–3 days)**
+  - Redesign EntityStore with canonical schema JSON and provenance.
+  - ✅ Acceptance: round-trip tests ensuring reconstruction and provenance integrity.
+
+- **M5: API & Documentation (1–2 days)**
+  - Narrow exports, mark internals, update README/docgen.
+  - ✅ Acceptance: `pnpm docgen`, updated README, stable public API summary.
+
+## Risks & Mitigations
+- **LLM determinism**: enforce strict JSON schema in prompt, add repair/validation via `Schema.decodeUnknownEffect`.
+- **Span accuracy**: regression tests for tokenizer offsets, including Unicode and whitespace edge cases.
+- **Annotation sprawl**: typed annotation schemas and controlled helper APIs.
+- **Performance**: cache prompt renderings and schema hashes to avoid redundant traversals.
+
+## Immediate Next Steps
+1. Implement `src/Extraction/Annotations.ts` and refactor `AnnotationParser` to use typed annotations.
+2. Refactor `ASTTraverse` to pure typed tree with unit tests.
+3. Scaffold `Prompt.ts` rendering logic with initial snapshots.
+

--- a/specs/README.md
+++ b/specs/README.md
@@ -1,0 +1,3 @@
+# Feature Specifications
+
+- [ ] **[typed-annotation](./typed-annotation/)** - Establish typed annotation schemas and helpers for Effect-based domain models

--- a/specs/typed-annotation/design.md
+++ b/specs/typed-annotation/design.md
@@ -1,0 +1,115 @@
+# Design — Typed Annotation Spec
+
+## 1. Module Structure
+
+```
+src/
+  Extraction/
+    Annotations.ts        # typed annotation schemas + helpers + accessors
+    AnnotationParser.ts   # updated to use typed annotations
+    ASTTraverse.ts        # updated to rely on typed accessors
+```
+
+### 1.1 `src/Extraction/Annotations.ts`
+- Export namespace `Annotations` with:
+  - Schema definitions (`Core`, `Role`, `Semantic`, `Provenance`).
+  - Types inferred via `Schema.Schema.Type<typeof ...>`.
+  - Helper functions to apply annotations (`withCore`, `withRole`, `withSemantic`, `withProvenance`, `withMetadata` for combinations).
+  - Typed getters (`getCore`, `getRole`, `getSemantic`, `getProvenance`).
+- Implementation details:
+  - Use `Schema.Struct` for definitions and `.pipe(Schema.brand(...))` where needed.
+  - Encode helpers call `Schema.encodeSync` on the annotation schema, then spread onto `Schema.annotations` along with existing ones.
+  - Maintain compatibility with Effect built-in annotations by reusing constants from `SchemaAST` (e.g., `SchemaAST.SemanticAnnotationId` if available) or define project-specific symbols via `Symbol.for("effect-nlp/annotations/..." )`.
+  - Provide helper overloads for chaining with `pipe` (data-first / data-last pattern using `Function.dual` with arity ≥ 2).
+
+### 1.2 Typed Getters
+- Wrap `SchemaAST.getAnnotation` from Effect to return typed `Option` values using the annotation schemas' decoders.
+- When decoding stored annotation objects, use `Schema.decodeUnknown` (effectful) producing `Effect` values; provide convenience wrappers that return `Option` with safe fallback (e.g., decode errors map to `Option.none`).
+- Export a `Context` type bundling optional annotation types for convenience when building prompts.
+
+### 1.3 Integration Updates
+- `AnnotationParser.ts`:
+  - Replace ad-hoc `Option.fromNullable(annotations[key])` with typed getters from `Annotations` module.
+  - Ensure metadata HashMap only receives unknown keys not covered by typed annotations.
+- `ASTTraverse.ts`:
+  - Update context extraction to use typed getters, exposing strongly typed annotation context.
+  - Provide helper for merging core, role, semantic, provenance into node context.
+- Example schemas (`src/examples/...`):
+  - Replace raw `.annotations({ ... })` with helper functions (e.g., `Schema.String.pipe(Annotations.withCore({ title: "Name" }))`).
+
+## 2. Data Types & Symbols
+
+### 2.1 Symbols
+- Define constants for annotation keys to ensure consistent usage:
+  - `const RoleAnnotationId = Symbol.for("effect-nlp/annotation/role");`
+  - `const SemanticAnnotationId = Symbol.for("effect-nlp/annotation/semantic");`
+  - `const ProvenanceAnnotationId = Symbol.for("effect-nlp/annotation/provenance");`
+- For fields overlapping with Effect built-ins (`title`, `description`, etc.), rely on existing `SchemaAST` IDs rather than redefining.
+
+### 2.2 Schema Definitions
+- `Core`: `Schema.Struct({ title: Schema.optional(Schema.String), description: Schema.optional(Schema.String), examples: Schema.optional(Schema.Array(Schema.Unknown)), constraints: Schema.optional(Schema.Array(Schema.String)), documentation: Schema.optional(Schema.String) })`.
+- `Role`: `Schema.Struct({ role: Schema.String })` (optionally brand Role string for future safety).
+- `Semantic`: `Schema.Struct({ semanticType: Schema.String })`.
+- `Provenance`: `Schema.Struct({ source: Schema.optional(Schema.String), comment: Schema.optional(Schema.String) })`.
+
+## 3. Helper API Design
+
+### 3.1 Application Helpers
+- Example signature using `Function.dual` arity 2:
+  ```ts
+  const withSemantic = Function.dual<
+    (semantic: Annotations.Semantic) => <A, I, R>(schema: Schema.Schema<A, I, R>) => Schema.Schema<A, I, R>,
+    <A, I, R>(schema: Schema.Schema<A, I, R>, semantic: Annotations.Semantic) => Schema.Schema<A, I, R>
+  >(2, (schema, semantic) => schema.annotations(Annotations.encodeSemantic(semantic)));
+  ```
+- `encodeSemantic` returns a record keyed by `SemanticAnnotationId` with a JSON-friendly value.
+- Provide combined helper `withMetadata` that accepts partial structures and applies multiple annotation types in one call (useful for example schemas).
+
+### 3.2 Retrieval Helpers
+- Provide pure helpers returning `Option`:
+  ```ts
+  const getSemantic = (annotated: SchemaAST.Annotated): Option.Option<Annotations.Semantic> =>
+    pipe(
+      SchemaAST.getAnnotation<Record<string, unknown>>(SemanticAnnotationId)(annotated),
+      Option.flatMap(Annotations.decodeSemanticOption)
+    );
+  ```
+- `decodeSemanticOption` uses `Schema.decodeUnknownOption` (wrap decode in `Effect` then convert to `Option`).
+- Aggregated context helper `getContext(annotated)` returns `{ core?: ..., role?: ..., semantic?: ..., provenance?: ... }` all inside `Option` for downstream use.
+
+## 4. Refactor Plan
+
+### 4.1 AnnotationParser Refactor
+- Replace manual extraction logic with typed helpers.
+- Ensure metadata HashMap excludes keys handled by typed annotations to avoid duplication.
+- Update tests/examples to assert typed context contents.
+
+### 4.2 AST Traversal Refactor
+- Update context building to rely on `Annotations.getContext`.
+- Provide strongly typed node context interface consumed by prompt/extraction pipeline.
+
+### 4.3 Example Schema Updates
+- Choose representative examples (Person, Organization) and refactor to use helper functions.
+- Update documentation fragments to illustrate new API.
+
+## 5. Testing Strategy
+
+### 5.1 Unit Tests in `test/unit`
+- New test file `Annotations.test.ts` covering:
+  - Encoding/decoding for each annotation schema.
+  - `with*` helper application and AST inspection (`schema.ast.annotations[Symbol]`).
+  - Accessor functions returning expected `Option` values.
+  - Round-trip (apply -> retrieve -> deepEqual input).
+
+### 5.2 Regression Tests
+- Update existing tests that inspect annotations to expect typed structures.
+- Add test ensuring metadata HashMap in `AnnotationParser` excludes keys handled by typed helpers.
+
+## 6. Risks & Mitigations
+- **Symbol collisions**: mitigate by using unique `Symbol.for` keys namespaced with `effect-nlp`.
+- **Decode failures**: ensure accessors handle decoding errors gracefully (log or treat as absence).
+- **Compatibility with built-ins**: test combination of mixed annotations (Effect-provided + typed) on the same schema.
+
+## 7. Documentation
+- Update README section or add dedicated docs snippet describing annotation helpers and illustrating how semantic annotations influence extraction prompts.
+- Inline doc comments in `Annotations.ts` referencing usage patterns for schema authors.

--- a/specs/typed-annotation/instructions.md
+++ b/specs/typed-annotation/instructions.md
@@ -1,0 +1,31 @@
+# Typed Annotation Spec
+
+## Feature Overview
+Implement a strongly typed annotation layer on top of Effect Schema so that domain schemas in this repository can rely on first-class, reusable annotation definitions. The feature should introduce a canonical `Annotations` module that defines structured annotation schemas (title, semantic type, roles, provenance, etc.) and helper APIs that make it simple to attach and retrieve these annotations from Effect schemas and AST nodes. The goal is to guarantee consistent metadata for prompt generation, entity extraction, and storage while remaining fully compatible with Effect's native annotation mechanisms.
+
+## User Stories
+- **Schema authors** want to attach rich semantic metadata to schemas using a safe, discoverable API so that downstream tooling can rely on consistent annotation shapes.
+- **Extraction engine developers** need typed helpers to read annotations from the Schema AST without manual casting, enabling deterministic prompt construction and entity provenance.
+- **Library consumers** expect annotations to be validated and documented so they can extend schemas confidently without breaking tooling.
+
+## Acceptance Criteria
+- A new module `src/Extraction/Annotations.ts` exports typed annotation schemas (`CoreAnnotations`, `RoleAnnotation`, `SemanticAnnotation`, `IdentifierAnnotation`, optional `ProvenanceAnnotation`) and derived helper types.
+- Helper functions exist for applying annotations to schemas (`annotate`, `annotateField`, etc.) and for retrieving annotations from Schema AST nodes using typed getters.
+- Existing code that currently applies ad-hoc annotation objects is refactored to use the new helpers where applicable (minimum: AnnotationParser, AST traversal utilities, example schemas).
+- Tests cover encoding/decoding of annotations and validate that the helpers round-trip (attach -> retrieve) without type assertions.
+- Documentation is updated (README or module docs) showing how to use the annotation helpers for defining schemas.
+
+## Constraints
+- Must remain compatible with Effect Schema's native annotation system and not introduce breaking changes to schema construction.
+- Avoid mutation of existing AST structures; helpers should operate using pure transformations or Effect Schema APIs.
+- No introduction of external dependencies beyond existing Effect packages.
+- Ensure TypeScript type safety: no `as any` or unchecked casts in the new module.
+
+## Dependencies
+- Relies on current Effect Schema and Schema AST APIs (`Schema.annotations`, `SchemaAST.getAnnotation`, etc.).
+- Builds on the tokenizer and extraction components that will consume annotations for prompt generation.
+
+## Out of Scope
+- Implementing the prompt builder or LLM extraction pipeline (covered by separate features).
+- Persisting annotation metadata into the entity store beyond what already exists.
+- Refactoring every existing schema in the repository; focus on core modules and representative examples to validate the approach.

--- a/specs/typed-annotation/plan.md
+++ b/specs/typed-annotation/plan.md
@@ -1,0 +1,42 @@
+# Implementation Plan — Typed Annotation Spec
+
+## 1. Module Implementation
+1. Create `src/Extraction/Annotations.ts`.
+   - Define annotation symbols (`RoleAnnotationId`, `SemanticAnnotationId`, `ProvenanceAnnotationId`).
+   - Implement annotation schemas and inferred types.
+   - Provide encode/decode helpers for each schema.
+   - Implement helper functions (`withCore`, `withRole`, `withSemantic`, `withProvenance`, `withMetadata`).
+   - Implement typed getters (`getCore`, `getRole`, `getSemantic`, `getProvenance`, `getContext`).
+   - Add inline documentation for each helper.
+
+2. Update `src/Extraction/AnnotationParser.ts` to use typed getters.
+   - Replace manual extraction of built-in annotations with `Annotations.getCore`, etc.
+   - Adjust metadata collection to skip keys handled by typed helpers.
+
+3. Update `src/Extraction/ASTTraverse.ts`.
+   - Import `Annotations` and leverage `getContext` when building node context.
+   - Ensure tree nodes expose typed context fields (core/role/semantic/provenance).
+
+4. Update representative example schemas (e.g., `src/examples/annotation-parser-test.ts`, `src/examples/ast-traversal-corrected-test.ts`).
+   - Replace manual annotations with helper functions.
+   - Ensure examples compile and remain illustrative.
+
+## 2. Testing
+1. Create `test/unit/Annotations.test.ts` covering:
+   - Encoding/decoding (apply helper, inspect AST, retrieve via getter).
+   - Round-trip tests (input record -> attach -> retrieve -> deepEqual).
+   - Absence handling (ensure getters return `Option.none`).
+
+2. Update existing tests impacted by annotation changes (e.g., annotation parser tests) to expect typed structures.
+
+## 3. Documentation
+1. Add documentation snippet (README or module JSDoc) demonstrating annotation helpers and explaining how semantic metadata surfaces during extraction/prompt generation.
+
+## 4. Validation & QA
+1. Run `pnpm lint --fix` on updated files (Annotations module, modified extraction files, tests, docs).
+2. Run `pnpm tsc` to ensure type safety.
+3. Execute relevant tests (`pnpm test` targeting new/updated suites).
+
+## 5. Post-Implementation
+1. Review final API exports to ensure `Annotations` is exposed appropriately (and mark as part of public or internal API per decision).
+2. Ensure branch up-to-date and ready for PR (no loose TODOs, check formatting).

--- a/specs/typed-annotation/requirements.md
+++ b/specs/typed-annotation/requirements.md
@@ -1,0 +1,55 @@
+# Requirements — Typed Annotation Spec
+
+## 1. Functional Requirements
+
+### 1.1 Annotation Schemas
+- Provide reusable schema definitions for core annotation categories tailored to the entity/extraction workflow:
+  - `CoreAnnotations`: optional `title`, `description`, `examples`, `constraints`, `documentation`.
+  - `RoleAnnotation`: required `role` string.
+  - `SemanticAnnotation`: required `semanticType` string.
+  - `ProvenanceAnnotation`: optional `source` and `comment` strings.
+- Export branded types and helper codecs for each annotation schema using Effect Schema primitives.
+
+### 1.2 Entity-Focused Helper APIs
+- Provide helper functions (e.g., `withCoreAnnotations`, `withSemanticType`, `withEntityRole`, `withProvenance`) that accept typed annotation records, encode them with the schema definitions, and delegate to `Schema.annotations`.
+- Helpers MUST compose with `pipe` and preserve the original schema’s typing.
+- Helpers SHALL never shadow or replace Effect’s native annotation functions; they only encode our typed structures before applying them.
+- Where appropriate, provide variants specialized for entity schemas (e.g., convenience helpers combining role + semantic type).
+
+### 1.3 Typed Accessors for Schema AST
+- Implement accessor functions (`getCoreAnnotations`, `getSemanticAnnotation`, `getRoleAnnotation`, `getProvenanceAnnotation`) returning `Option`-wrapped typed values when reading from `SchemaAST.Annotated` nodes.
+- Accessors MUST rely on Effect’s `SchemaAST.getAnnotation` with the proper symbol keys to stay compatible with upstream updates.
+- Retrieval MUST be type-safe (no `as any`) and support defaulting when annotations are absent.
+
+### 1.4 Integration with Existing Modules
+- Refactor `AnnotationParser` and AST traversal utilities to consume the new typed helpers for both attaching and retrieving annotations.
+- Update representative example schemas to demonstrate the helper functions.
+- Confirm compatibility with existing annotations in the repository (Effect built-ins such as identifier/title/description remain usable alongside the new helpers).
+
+### 1.5 Testing
+- Unit tests SHALL validate:
+  - Encoding/decoding of each annotation schema.
+  - Helper functions apply annotations and produce AST nodes containing encoded metadata.
+  - Accessor functions retrieve annotations accurately and return `Option.none` when missing.
+  - Round-trip scenarios (apply -> retrieve -> deepEqual) for representative schemas.
+- Tests MUST rely only on public Effect APIs.
+
+### 1.6 Documentation
+- Update README or module-level documentation to introduce the typed annotation helpers and show usage patterns during schema definition.
+- Include at least one example explaining how semantic annotations can be surfaced during prompt construction or extraction logic.
+
+## 2. Non-Functional Requirements
+- Maintain strict TypeScript type safety (no unchecked casts) in new modules and refactored code.
+- Ensure all touched files pass linting (`pnpm lint --fix <file>`).
+- Favor immutable, pure operations; avoid mutating AST nodes directly.
+- Keep compatibility with the project’s current Effect version and annotation APIs.
+
+## 3. Constraints & Assumptions
+- Assume Effect’s annotation symbols and APIs remain stable for this feature.
+- No new third-party dependencies.
+- Multiple annotations may coexist on a schema; helpers must merge with existing annotations without loss.
+- Annotations may be optional; absence must not cause runtime failures.
+
+## 4. Acceptance Validation
+- Feature is complete when acceptance criteria in `instructions.md` are met, including module implementation, refactors, tests, and documentation.
+- Reviewers can verify by inspecting `src/Extraction/Annotations.ts`, updated modules, and the associated test suite.

--- a/src/Extraction/Annotations.ts
+++ b/src/Extraction/Annotations.ts
@@ -1,0 +1,243 @@
+import { Function, Option, Schema, SchemaAST, pipe } from "effect";
+
+/**
+ * Namespace providing typed annotations and utilities for entity schemas.
+ */
+export namespace Annotations {
+  const ConstraintsAnnotationId = Symbol.for(
+    "effect-nlp/annotation/constraints"
+  );
+  const RoleAnnotationId = Symbol.for("effect-nlp/annotation/role");
+  const SemanticAnnotationId = Symbol.for("effect-nlp/annotation/semantic");
+  const ProvenanceAnnotationId = Symbol.for(
+    "effect-nlp/annotation/provenance"
+  );
+
+  const ConstraintsSchema = Schema.Array(Schema.String);
+
+  export const Core = Schema.Struct({
+    title: Schema.optional(Schema.String),
+    description: Schema.optional(Schema.String),
+    examples: Schema.optional(Schema.Array(Schema.Unknown)),
+    constraints: Schema.optional(ConstraintsSchema),
+    documentation: Schema.optional(Schema.String),
+  });
+  export type Core = Schema.Schema.Type<typeof Core>;
+
+  export const Role = Schema.Struct({ role: Schema.String });
+  export type Role = Schema.Schema.Type<typeof Role>;
+
+  export const Semantic = Schema.Struct({ semanticType: Schema.String });
+  export type Semantic = Schema.Schema.Type<typeof Semantic>;
+
+  export const Provenance = Schema.Struct({
+    source: Schema.optional(Schema.String),
+    comment: Schema.optional(Schema.String),
+  });
+  export type Provenance = Schema.Schema.Type<typeof Provenance>;
+
+  export interface Metadata {
+    readonly core?: Core;
+    readonly role?: Role;
+    readonly semantic?: Semantic;
+    readonly provenance?: Provenance;
+  }
+
+  const encodeCore = (core: Core): Record<PropertyKey, unknown> => {
+    const encoded = Schema.encodeSync(Core)(core);
+    const annotations: Record<PropertyKey, unknown> = {};
+
+    if (encoded.title !== undefined) {
+      annotations.title = encoded.title;
+    }
+    if (encoded.description !== undefined) {
+      annotations.description = encoded.description;
+    }
+    if (encoded.examples !== undefined) {
+      annotations.examples = encoded.examples;
+    }
+    if (encoded.documentation !== undefined) {
+      annotations.documentation = encoded.documentation;
+    }
+    if (encoded.constraints !== undefined) {
+      annotations[ConstraintsAnnotationId] = encoded.constraints;
+    }
+
+    return annotations;
+  };
+
+  const encodeRole = (role: Role): Record<PropertyKey, unknown> => ({
+    [RoleAnnotationId]: Schema.encodeSync(Role)(role),
+  });
+
+  const encodeSemantic = (semantic: Semantic): Record<PropertyKey, unknown> => ({
+    [SemanticAnnotationId]: Schema.encodeSync(Semantic)(semantic),
+  });
+
+  const encodeProvenance = (
+    provenance: Provenance
+  ): Record<PropertyKey, unknown> => ({
+    [ProvenanceAnnotationId]: Schema.encodeSync(Provenance)(provenance),
+  });
+
+  const mergeAnnotations = (
+    annotations: ReadonlyArray<Record<PropertyKey, unknown>>
+  ): Record<PropertyKey, unknown> =>
+    annotations.reduce<Record<PropertyKey, unknown>>(
+      (acc, current) => ({ ...acc, ...current }),
+      {}
+    );
+
+  export const withCore = Function.dual(
+    2,
+    <A, I, R>(schema: Schema.Schema<A, I, R>, core: Core) =>
+      schema.annotations(encodeCore(core))
+  );
+
+  export const withRole = Function.dual(
+    2,
+    <A, I, R>(schema: Schema.Schema<A, I, R>, role: Role) =>
+      schema.annotations(encodeRole(role))
+  );
+
+  export const withSemantic = Function.dual(
+    2,
+    <A, I, R>(schema: Schema.Schema<A, I, R>, semantic: Semantic) =>
+      schema.annotations(encodeSemantic(semantic))
+  );
+
+  export const withProvenance = Function.dual(
+    2,
+    <A, I, R>(schema: Schema.Schema<A, I, R>, provenance: Provenance) =>
+      schema.annotations(encodeProvenance(provenance))
+  );
+
+  export const withMetadata = Function.dual(
+    2,
+    <A, I, R>(schema: Schema.Schema<A, I, R>, metadata: Metadata) =>
+      schema.annotations(
+        mergeAnnotations([
+          metadata.core ? encodeCore(metadata.core) : {},
+          metadata.role ? encodeRole(metadata.role) : {},
+          metadata.semantic ? encodeSemantic(metadata.semantic) : {},
+          metadata.provenance ? encodeProvenance(metadata.provenance) : {},
+        ])
+      )
+  );
+
+  const decodeUsing = <A>(
+    decoder: (input: unknown) => Option.Option<A>
+  ): ((value: unknown) => Option.Option<A>) => decoder;
+
+  const decodeConstraints = decodeUsing(
+    Schema.decodeUnknownOption(ConstraintsSchema)
+  );
+  const decodeRole = decodeUsing(Schema.decodeUnknownOption(Role));
+  const decodeSemantic = decodeUsing(Schema.decodeUnknownOption(Semantic));
+  const decodeProvenance = decodeUsing(
+    Schema.decodeUnknownOption(Provenance)
+  );
+
+  export const getCore = (
+    annotations: SchemaAST.Annotations
+  ): Option.Option<Core> => {
+    const title = Option.fromNullable<SchemaAST.TitleAnnotation>(
+      annotations[SchemaAST.TitleAnnotationId] as
+        | SchemaAST.TitleAnnotation
+        | undefined
+    );
+    const description = Option.fromNullable<SchemaAST.DescriptionAnnotation>(
+      annotations[SchemaAST.DescriptionAnnotationId] as
+        | SchemaAST.DescriptionAnnotation
+        | undefined
+    );
+    const examples = Option.fromNullable<
+      SchemaAST.ExamplesAnnotation<unknown>
+    >(
+      annotations[SchemaAST.ExamplesAnnotationId] as
+        | SchemaAST.ExamplesAnnotation<unknown>
+        | undefined
+    );
+    const documentation = Option.fromNullable<
+      SchemaAST.DocumentationAnnotation
+    >(
+      annotations[SchemaAST.DocumentationAnnotationId] as
+        | SchemaAST.DocumentationAnnotation
+        | undefined
+    );
+    const constraints = pipe(
+      Option.fromNullable(annotations[ConstraintsAnnotationId]),
+      Option.flatMap(decodeConstraints)
+    );
+
+    if (
+      Option.isNone(title) &&
+      Option.isNone(description) &&
+      Option.isNone(examples) &&
+      Option.isNone(documentation) &&
+      Option.isNone(constraints)
+    ) {
+      return Option.none();
+    }
+
+    const builder: Record<string, unknown> = {};
+
+    if (Option.isSome(title)) {
+      builder.title = title.value;
+    }
+    if (Option.isSome(description)) {
+      builder.description = description.value;
+    }
+    if (Option.isSome(examples)) {
+      builder.examples = examples.value;
+    }
+    if (Option.isSome(documentation)) {
+      builder.documentation = documentation.value;
+    }
+    if (Option.isSome(constraints)) {
+      builder.constraints = constraints.value;
+    }
+
+    return pipe(builder, Schema.decodeUnknownOption(Core));
+  };
+
+  export const getRole = (
+    annotations: SchemaAST.Annotations
+  ): Option.Option<Role> =>
+    pipe(
+      Option.fromNullable(annotations[RoleAnnotationId]),
+      Option.flatMap(decodeRole)
+    );
+
+  export const getSemantic = (
+    annotations: SchemaAST.Annotations
+  ): Option.Option<Semantic> =>
+    pipe(
+      Option.fromNullable(annotations[SemanticAnnotationId]),
+      Option.flatMap(decodeSemantic)
+    );
+
+  export const getProvenance = (
+    annotations: SchemaAST.Annotations
+  ): Option.Option<Provenance> =>
+    pipe(
+      Option.fromNullable(annotations[ProvenanceAnnotationId]),
+      Option.flatMap(decodeProvenance)
+    );
+
+  export interface Context {
+    readonly core: Option.Option<Core>;
+    readonly role: Option.Option<Role>;
+    readonly semantic: Option.Option<Semantic>;
+    readonly provenance: Option.Option<Provenance>;
+  }
+
+  export const getContext = (
+    annotations: SchemaAST.Annotations
+  ): Context => ({
+    core: getCore(annotations),
+    role: getRole(annotations),
+    semantic: getSemantic(annotations),
+    provenance: getProvenance(annotations),
+  });
+}

--- a/src/NLP/Core/PatternOperations.ts
+++ b/src/NLP/Core/PatternOperations.ts
@@ -19,7 +19,6 @@ import {
   type WinkPOSTag,
   type WinkEntityType,
 } from "./Pattern.js";
-import { make } from "./PatternBuilders.js";
 
 // ============================================================================
 // PREDICATE-BASED PATTERN VALIDATION AND FILTERING

--- a/src/examples/annotation-parser-test.ts
+++ b/src/examples/annotation-parser-test.ts
@@ -16,129 +16,153 @@ import {
   filterAnnotations,
   createAnnotatedSchema,
 } from "../Extraction/AnnotationParser.js";
+import { Annotations } from "../Extraction/Annotations.js";
 
 // ============================================================================
 // CREATE TEST SCHEMA WITH ANNOTATIONS
 // ============================================================================
 
 // Deep nested schema for testing
-const AddressSchema = Schema.Struct({
-  street: Schema.String.pipe(
-    Schema.annotations({
-      identifier: "street",
-      title: "Street",
-    })
-  ),
-  city: Schema.String.pipe(
-    Schema.annotations({
-      identifier: "city",
-      title: "City",
-    })
-  ),
-  country: Schema.String.pipe(
-    Schema.annotations({
-      identifier: "country",
-      title: "Country",
-    })
-  ),
-}).annotations({
-  identifier: "AddressSchema",
-  title: "Address",
-  semanticType: "address",
-});
-
-const ContactSchema = Schema.Struct({
-  phone: Schema.String.pipe(
-    Schema.annotations({
-      identifier: "phone",
-      title: "Phone",
-    })
-  ),
-  email: Schema.String.pipe(
-    Schema.annotations({
-      identifier: "email",
-      title: "Email",
-    })
-  ),
-}).annotations({
-  identifier: "ContactSchema",
-  title: "Contact",
-  semanticType: "contact",
-});
-
-const PersonSchema = Schema.Struct({
-  name: Schema.String.pipe(
-    Schema.annotations({
-      identifier: "name",
-      title: "Name",
-    })
-  ),
-  age: Schema.Number.pipe(
-    Schema.annotations({
-      identifier: "age",
-      title: "Age",
-    })
-  ),
-  address: AddressSchema.pipe(
-    Schema.annotations({
-      identifier: "address",
+const AddressSchema = pipe(
+  Schema.Struct({
+    street: pipe(
+      Schema.String,
+      Annotations.withCore({
+        title: "Street",
+      }),
+      Schema.annotations({ identifier: "street" })
+    ),
+    city: pipe(
+      Schema.String,
+      Annotations.withCore({
+        title: "City",
+      }),
+      Schema.annotations({ identifier: "city" })
+    ),
+    country: pipe(
+      Schema.String,
+      Annotations.withCore({
+        title: "Country",
+      }),
+      Schema.annotations({ identifier: "country" })
+    ),
+  }),
+  Annotations.withMetadata({
+    core: {
       title: "Address",
-    })
-  ),
-  contacts: Schema.Array(ContactSchema).pipe(
-    Schema.annotations({
-      identifier: "contacts",
-      title: "Contacts",
-    })
-  ),
-  tags: Schema.Array(Schema.String).pipe(
-    Schema.annotations({
-      identifier: "tags",
-      title: "Tags",
-    })
-  ),
-  metadata: Schema.Record({ key: Schema.String, value: Schema.String }).pipe(
-    Schema.annotations({
-      identifier: "metadata",
-      title: "Metadata",
-    })
-  ),
-}).annotations({
-  identifier: "PersonSchema",
-  title: "Person",
-  semanticType: "person",
-});
+    },
+    semantic: { semanticType: "address" },
+  }),
+  Schema.annotations({ identifier: "AddressSchema" })
+);
 
-const OrganizationSchema = Schema.Struct({
-  name: Schema.String.pipe(
-    Schema.annotations({
-      identifier: "name",
+const ContactSchema = pipe(
+  Schema.Struct({
+    phone: pipe(
+      Schema.String,
+      Annotations.withCore({ title: "Phone" }),
+      Schema.annotations({ identifier: "phone" })
+    ),
+    email: pipe(
+      Schema.String,
+      Annotations.withCore({ title: "Email" }),
+      Schema.annotations({ identifier: "email" })
+    ),
+  }),
+  Annotations.withMetadata({
+    core: {
+      title: "Contact",
+    },
+    semantic: { semanticType: "contact" },
+  }),
+  Schema.annotations({ identifier: "ContactSchema" })
+);
+
+const PersonSchema = pipe(
+  Schema.Struct({
+    name: pipe(
+      Schema.String,
+      Annotations.withCore({ title: "Name" }),
+      Schema.annotations({ identifier: "name" })
+    ),
+    age: pipe(
+      Schema.Number,
+      Annotations.withCore({ title: "Age" }),
+      Schema.annotations({ identifier: "age" })
+    ),
+    address: pipe(
+      AddressSchema,
+      Annotations.withMetadata({
+        core: { title: "Address" },
+      }),
+      Schema.annotations({ identifier: "address" })
+    ),
+    contacts: pipe(
+      Schema.Array(ContactSchema),
+      Annotations.withMetadata({
+        core: { title: "Contacts" },
+      }),
+      Schema.annotations({ identifier: "contacts" })
+    ),
+    tags: pipe(
+      Schema.Array(Schema.String),
+      Annotations.withMetadata({
+        core: { title: "Tags" },
+      }),
+      Schema.annotations({ identifier: "tags" })
+    ),
+    metadata: pipe(
+      Schema.Record({ key: Schema.String, value: Schema.String }),
+      Annotations.withMetadata({
+        core: { title: "Metadata" },
+      }),
+      Schema.annotations({ identifier: "metadata" })
+    ),
+  }),
+  Annotations.withMetadata({
+    core: {
+      title: "Person",
+    },
+    semantic: { semanticType: "person" },
+  }),
+  Schema.annotations({ identifier: "PersonSchema" })
+);
+
+const OrganizationSchema = pipe(
+  Schema.Struct({
+    name: pipe(
+      Schema.String,
+      Annotations.withCore({ title: "Organization" }),
+      Schema.annotations({ identifier: "name" })
+    ),
+    address: pipe(
+      Schema.String,
+      Annotations.withCore({ title: "Address" }),
+      Schema.annotations({ identifier: "address" })
+    ),
+    ceo: pipe(
+      PersonSchema,
+      Annotations.withMetadata({
+        core: { title: "CEO" },
+      }),
+      Schema.annotations({ identifier: "ceo" })
+    ),
+    departments: pipe(
+      Schema.Array(PersonSchema),
+      Annotations.withMetadata({
+        core: { title: "Departments" },
+      }),
+      Schema.annotations({ identifier: "departments" })
+    ),
+  }),
+  Annotations.withMetadata({
+    core: {
       title: "Organization",
-    })
-  ),
-  address: Schema.String.pipe(
-    Schema.annotations({
-      identifier: "address",
-      title: "Address",
-    })
-  ),
-  ceo: PersonSchema.pipe(
-    Schema.annotations({
-      identifier: "ceo",
-      title: "CEO",
-    })
-  ),
-  departments: Schema.Array(PersonSchema).pipe(
-    Schema.annotations({
-      identifier: "departments",
-      title: "Departments",
-    })
-  ),
-}).annotations({
-  identifier: "OrganizationSchema",
-  title: "Organization",
-  semanticType: "organization",
-});
+    },
+    semantic: { semanticType: "organization" },
+  }),
+  Schema.annotations({ identifier: "OrganizationSchema" })
+);
 
 // ============================================================================
 // TEST FUNCTION

--- a/src/examples/ast-traversal-simple-test.ts
+++ b/src/examples/ast-traversal-simple-test.ts
@@ -2,7 +2,7 @@
  * Simple AST Traversal Test - Debug version
  */
 
-import { Schema, Effect, pipe, Console } from "effect";
+import { Schema, Effect, Option, Console } from "effect";
 import { buildSchemaASTTree } from "../Extraction/ASTTraverse.js";
 
 // Simple test schema
@@ -22,10 +22,26 @@ const debugASTTraversal = Effect.gen(function* (_) {
   const tree = yield* _(buildSchemaASTTree(TestSchema));
   
   yield* _(Console.log("✓ Schema AST Tree built successfully"));
-  yield* _(Console.log(`Root node identifier: ${tree.root.context.identifier}`));
-  yield* _(Console.log(`Root node title: ${tree.root.context.title}`));
-  yield* _(Console.log(`Root node description: ${tree.root.context.description}`));
-  yield* _(Console.log(`Root node semantic type: ${tree.root.context.semanticType}`));
+  const core = tree.root.context.annotations.core;
+  yield* _(
+    Console.log(
+      `Root node title: ${Option.getOrElse(core, () => ({ title: "" })).title ?? ""}`
+    )
+  );
+  yield* _(
+    Console.log(
+      `Root node description: ${
+        Option.getOrElse(core, () => ({ description: "" })).description ?? ""
+      }`
+    )
+  );
+  yield* _(
+    Console.log(
+      `Root node semantic type: ${
+        Option.getOrElse(tree.root.context.semanticType, () => "unknown")
+      }`
+    )
+  );
   yield* _(Console.log(`Root node path: ${tree.root.path.join(".")}`));
   yield* _(Console.log(`Root node children count: ${tree.root.children.length}`));
   yield* _(Console.log(""));
@@ -34,7 +50,9 @@ const debugASTTraversal = Effect.gen(function* (_) {
   tree.root.children.forEach((child, index) => {
     console.log(`Child ${index + 1}:`);
     console.log(`  Path: ${child.path.join(".")}`);
-    console.log(`  Role: ${child.context.role}`);
+    console.log(
+      `  Role: ${Option.getOrElse(child.context.annotations.role, () => ({ role: "" })).role}`
+    );
     console.log(`  Type: ${child.context.semanticType}`);
     console.log("");
   });

--- a/src/examples/entity-debug-test.ts
+++ b/src/examples/entity-debug-test.ts
@@ -1,11 +1,5 @@
 import { Effect, Schema, Console } from "effect";
-import {
-  MakeEntitySchema,
-  MakeEntityId,
-  MakeSchemaId,
-  EntityId,
-  SchemaId,
-} from "../Extraction/Entity.js";
+import { MakeEntitySchema, MakeEntityId, MakeSchemaId } from "../Extraction/Entity.js";
 
 const debugEntityAnnotations = () =>
   Effect.gen(function* () {
@@ -69,5 +63,4 @@ const debugEntityAnnotations = () =>
 
 // Run the debug test
 Effect.runPromise(debugEntityAnnotations()).catch(console.error);
-
 

--- a/src/examples/entity-store-test.ts
+++ b/src/examples/entity-store-test.ts
@@ -8,15 +8,7 @@
  */
 
 import { Schema, Effect, Console, pipe, Option } from "effect";
-import { KeyValueStore, layerMemory } from "@effect/platform/KeyValueStore";
-import {
-  MakeEntity,
-  MakeEntityId,
-  MakeSchemaId,
-  EntityId,
-  SchemaId,
-  EntityHash,
-} from "../Extraction/Entity.js";
+import { MakeEntity, EntityHash } from "../Extraction/Entity.js";
 import {
   EntityStoreService,
   storeEntity,

--- a/src/examples/parsejson-demo.ts
+++ b/src/examples/parsejson-demo.ts
@@ -1,4 +1,4 @@
-import { Effect, Schema, pipe, Console } from "effect";
+import { Effect, Schema, Console } from "effect";
 import { MakeEntity } from "../Extraction/Entity.js";
 
 // ============================================================================

--- a/src/examples/schema-serialization-test.ts
+++ b/src/examples/schema-serialization-test.ts
@@ -1,4 +1,4 @@
-import { Effect, Schema, pipe, Console , JSONSchema } from "effect";
+import { Effect, Schema, Console, JSONSchema } from "effect";
 import { MakeEntity, EntityHash } from "../Extraction/Entity.js";
 
 // ============================================================================

--- a/src/examples/simple-entity-test.ts
+++ b/src/examples/simple-entity-test.ts
@@ -1,7 +1,6 @@
 import { Effect, Schema, Console } from "effect";
 import {
   buildSchemaASTTree,
-  extractContextAtPath,
   generatePromptContext,
 } from "../Extraction/ASTTraverse.js";
 import {

--- a/test/unit/Annotations.test.ts
+++ b/test/unit/Annotations.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { Option, Schema, pipe } from "effect";
+import { Annotations } from "../../src/Extraction/Annotations.js";
+
+describe("Annotations", () => {
+  it("attaches core annotations and round-trips", () => {
+    const schema = pipe(
+      Schema.String,
+      Annotations.withCore({
+        title: "Title",
+        description: "Description",
+        documentation: "Doc",
+        constraints: ["Must be present"],
+      })
+    );
+
+    const core = Annotations.getCore(schema.ast.annotations);
+    expect(Option.isSome(core)).toBe(true);
+    const value = Option.getOrUndefined(core)!;
+    expect(value.title).toBe("Title");
+    expect(value.description).toBe("Description");
+    expect(value.constraints).toEqual(["Must be present"]);
+    expect(value.documentation).toBe("Doc");
+  });
+
+  it("merges metadata helpers", () => {
+    const schema = pipe(
+      Schema.String,
+      Annotations.withMetadata({
+        core: {
+          title: "StringValue",
+          description: "A string value",
+        },
+        role: { role: "field" },
+        semantic: { semanticType: "scalar" },
+        provenance: { source: "spec" },
+      })
+    );
+
+    const context = Annotations.getContext(schema.ast.annotations);
+    expect(Option.isSome(context.core)).toBe(true);
+    expect(Option.getOrUndefined(context.core)?.title).toBe("StringValue");
+    expect(Option.getOrUndefined(context.role)?.role).toBe("field");
+    expect(Option.getOrUndefined(context.semantic)?.semanticType).toBe(
+      "scalar"
+    );
+    expect(Option.getOrUndefined(context.provenance)?.source).toBe("spec");
+  });
+
+  it("returns None when no annotations present", () => {
+    const result = Annotations.getCore({});
+    expect(Option.isNone(result)).toBe(true);
+  });
+});

--- a/test/unit/PatternTypes.test.ts
+++ b/test/unit/PatternTypes.test.ts
@@ -4,7 +4,7 @@
  */
 
 import { describe, it, expect, beforeEach } from "vitest";
-import { Chunk, Data, Schema, Option } from "effect";
+import { Chunk, Data, Schema } from "effect";
 import {
   Pattern,
   POSPatternElement,


### PR DESCRIPTION
Add a new section in README.md detailing the typed annotation helpers available in the `src/Extraction/Annotations.ts` module, including usage examples for attaching and retrieving schema annotations. Refactor the AnnotationParser to utilize these helpers, improving the extraction of schema context and metadata. Update the schema context interface to include new annotation types, ensuring better integration and consistency across the codebase.